### PR TITLE
update responses

### DIFF
--- a/src/CentrifugoBroadcaster.php
+++ b/src/CentrifugoBroadcaster.php
@@ -59,7 +59,6 @@ class CentrifugoBroadcaster extends Broadcaster
             }
 
             return response($private ? $privateResponse : $response);
-
         } else {
             throw new HttpException(401);
         }

--- a/src/CentrifugoBroadcaster.php
+++ b/src/CentrifugoBroadcaster.php
@@ -53,8 +53,7 @@ class CentrifugoBroadcaster extends Broadcaster
 
                 if ($private = $this->isPrivateChannel($channel)) {
                     $privateResponse['channels'][] = $this->makeResponseForPrivateClient($is_access_granted, $channel, $client);
-                }
-                else {
+                } else {
                     $response[$channel] = $this->makeResponseForClient($is_access_granted, $client);
                 }
             }
@@ -95,7 +94,7 @@ class CentrifugoBroadcaster extends Broadcaster
 
         $response = $this->centrifugo->broadcast($this->formatChannels($channels), $payload);
 
-        if (is_array($response) && !isset($response['error'])) {
+        if (is_array($response) && ! isset($response['error'])) {
             return;
         }
 
@@ -140,7 +139,7 @@ class CentrifugoBroadcaster extends Broadcaster
     }
 
     /**
-     * Check channel name by $ symbol
+     * Check channel name by $ symbol.
      *
      * @param string $channel
      * @return bool
@@ -163,7 +162,7 @@ class CentrifugoBroadcaster extends Broadcaster
 
         return $access_granted ? [
             'sign' => $this->centrifugo->generateConnectionToken($client, 0, $info),
-            'info' => $info
+            'info' => $info,
         ] : [
             'status' => 403,
         ];
@@ -185,7 +184,7 @@ class CentrifugoBroadcaster extends Broadcaster
 
             'channel' => $channel,
             'token' => $this->centrifugo->generatePrivateChannelToken($client, $channel, 0, $info),
-            'info' => $this->centrifugo->info()
+            'info' => $this->centrifugo->info(),
 
         ] : [
             'status' => 403,

--- a/src/CentrifugoBroadcaster.php
+++ b/src/CentrifugoBroadcaster.php
@@ -90,8 +90,8 @@ class CentrifugoBroadcaster extends Broadcaster
     {
         $payload['event'] = $event;
         $channels = array_map(function ($channel) {
-            $channel = str_replace('private-', '$', $channel);
-        });
+            return str_replace('private-', '$', $channel);
+        }, $channels);
 
         $response = $this->centrifugo->broadcast($this->formatChannels($channels), $payload);
 

--- a/src/CentrifugoBroadcaster.php
+++ b/src/CentrifugoBroadcaster.php
@@ -51,10 +51,12 @@ class CentrifugoBroadcaster extends Broadcaster
                     $is_access_granted = false;
                 }
 
-                if ($private = $this->isPrivateChannel($channel))
+                if ($private = $this->isPrivateChannel($channel)) {
                     $privateResponse['channels'][] = $this->makeResponseForPrivateClient($is_access_granted, $channel, $client);
-                else
+                }
+                else {
                     $response[$channel] = $this->makeResponseForClient($is_access_granted, $client);
+                }
             }
 
             return response($private ? $privateResponse : $response);
@@ -87,7 +89,7 @@ class CentrifugoBroadcaster extends Broadcaster
     public function broadcast(array $channels, $event, array $payload = [])
     {
         $payload['event'] = $event;
-        $channels = array_map(function ($channel){
+        $channels = array_map(function ($channel) {
             $channel = str_replace('private-', '$', $channel);
         });
 
@@ -139,6 +141,7 @@ class CentrifugoBroadcaster extends Broadcaster
 
     /**
      * Check channel name by $ symbol
+     *
      * @param string $channel
      * @return bool
      */
@@ -160,7 +163,7 @@ class CentrifugoBroadcaster extends Broadcaster
 
         return $access_granted ? [
             'sign' => $this->centrifugo->generateConnectionToken($client, 0, $info),
-            'info' => $info,
+            'info' => $info
         ] : [
             'status' => 403,
         ];

--- a/src/CentrifugoBroadcaster.php
+++ b/src/CentrifugoBroadcaster.php
@@ -87,6 +87,9 @@ class CentrifugoBroadcaster extends Broadcaster
     public function broadcast(array $channels, $event, array $payload = [])
     {
         $payload['event'] = $event;
+        $channels = array_map(function ($channel){
+            $channel = str_replace('private-', '$', $channel);
+        });
 
         $response = $this->centrifugo->broadcast($this->formatChannels($channels), $payload);
 


### PR DESCRIPTION
- add private auth
- add right JSON response. Format from [docs](https://github.com/centrifugal/centrifuge-js):
```json
{
  "channels": [
    {
      "channel": "$chan1",
      "token": "<SUBSCRIPTION JWT TOKEN>"
    },
    {
      "channel": "$chan2",
      "token": "<SUBSCRIPTION JWT TOKEN>"
    }
  ]
}
```

- Laravel PrivateChannel to Centrifugo format
Change Laravel PrivateChannel prefix (private-) to Centrifugo format ($). Now can use 
```php
public function broadcastOn()
    {
        return new PrivateChannel('some.channel');
    }
```