### PR TITLE
Fix str_replace argument

### DIFF
--- a/src/CentrifugoBroadcaster.php
+++ b/src/CentrifugoBroadcaster.php
@@ -88,7 +88,7 @@ class CentrifugoBroadcaster extends Broadcaster
     {
         $payload['event'] = $event;
         $channels = array_map(function ($channel) {
-            return str_replace('private-', '$', $channel);
+            return str_replace('private-', '$', $channel->name);
         }, $channels);
 
         $response = $this->centrifugo->broadcast($this->formatChannels($channels), $payload);

--- a/src/CentrifugoBroadcaster.php
+++ b/src/CentrifugoBroadcaster.php
@@ -88,7 +88,7 @@ class CentrifugoBroadcaster extends Broadcaster
     {
         $payload['event'] = $event;
         $channels = array_map(function ($channel) {
-            return str_replace('private-', '$', $channel->name);
+            return str_replace('private-', '$', (string)$channel);
         }, $channels);
 
         $response = $this->centrifugo->broadcast($this->formatChannels($channels), $payload);


### PR DESCRIPTION
When we try to dispatch or broadcast our event using PrivateChannel, in the broadcast method, a PrivateChannel object is passed to str_replace, instead of a string. The result is a TypeError. This PR will fix it.