### PR TITLE
Remove keys from channels array on broadcasts

### DIFF
--- a/src/CentrifugoBroadcaster.php
+++ b/src/CentrifugoBroadcaster.php
@@ -89,7 +89,7 @@ class CentrifugoBroadcaster extends Broadcaster
         $payload['event'] = $event;
         $channels = array_map(function ($channel) {
             return str_replace('private-', '$', $channel);
-        }, $channels);
+        }, array_values($channels));
 
         $response = $this->centrifugo->broadcast($this->formatChannels($channels), $payload);
 


### PR DESCRIPTION
Using model broadcasting in Laravel, the incoming list of channels during `CentrifugoBroadcaster::broadcast` are keyed by 'name', so. e.g. channels may be:
```php
[
  'name' => 'Vendor.Package.Models.FancyExample.1'
]
```
causing the formatted json-encoded payload to centrifugo's API to be:
```json
{
  "method" : "broadcast",
  "params": {
    "channels": {
      "name":" Vendor.Package.Models.FancyExample.1"
    },
    "data": {
      ...
```
Centrifugo responds this with `{"error":{"code":107,"message":"bad request"}}`.

By stripping the incoming list of channels for keys (i.e. this pr), the array -> json encoding/casting gives the proper json format of the channel listing:

```json
"params": {
  "channels": [
    "Vendor.Package.Models.FancyExample.1"
  ]
}
```