### PR TITLE
Site-wide centrifugo namespace for all channels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /.idea
+composer.lock
+vendor

--- a/README.md
+++ b/README.md
@@ -50,12 +50,13 @@ Open your config/broadcasting.php and add new connection like this:
 
 ```php
         'centrifugo' => [
-            'driver' => 'centrifugo',
+            'driver'    => 'centrifugo',
             'token_hmac_secret_key'  => env('CENTRIFUGO_TOKEN_HMAC_SECRET_KEY',''),
-            'api_key'  => env('CENTRIFUGO_API_KEY',''),
-            'url'     => env('CENTRIFUGO_URL', 'http://localhost:8000'), // centrifugo api url
-            'verify'  => env('CENTRIFUGO_VERIFY', false), // Verify host ssl if centrifugo uses this
-            'ssl_key' => env('CENTRIFUGO_SSL_KEY', null), // Self-Signed SSl Key for Host (require verify=true)
+            'api_key'   => env('CENTRIFUGO_API_KEY',''),
+            'namespace' => env('CENTRIFUGO_NAMESPACE', ''),
+            'url'       => env('CENTRIFUGO_URL', 'http://localhost:8000'), // centrifugo api url
+            'verify'    => env('CENTRIFUGO_VERIFY', false), // Verify host ssl if centrifugo uses this
+            'ssl_key'   => env('CENTRIFUGO_SSL_KEY', null), // Self-Signed SSl Key for Host (require verify=true)
         ],
 ```
 
@@ -69,6 +70,7 @@ CENTRIFUGO_URL=http://localhost:8000
 
 These lines are optional:
 ```
+CENTRIFUGO_NAMESPACE=laravel
 CENTRIFUGO_SSL_KEY=/etc/ssl/some.pem
 CENTRIFUGO_VERIFY=false
 ```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Centrifugo broadcaster for laravel  , based on:
 - Compatible with latest [Centrifugo 3.1.0](https://github.com/centrifugal/centrifugo/releases/tag/v3.1.0) 🚀
 - Wrapper over [Centrifugo HTTP API](https://centrifugal.dev/docs/server/server_api) 🔌
 - Authentication with JWT token (HMAC algorithm) for anonymous, authenticated user and private channel 🗝️
+- Supports site-wide [Centrifugo namespace](https://centrifugal.dev/docs/server/channels#channel-namespaces)
 
 ## Requirements
 - PHP >= 7.3 , 8.0, 8.1
@@ -74,6 +75,14 @@ CENTRIFUGO_NAMESPACE=laravel
 CENTRIFUGO_SSL_KEY=/etc/ssl/some.pem
 CENTRIFUGO_VERIFY=false
 ```
+
+The `CENTRIFUGO_NAMESPACE` variable will move all channels into this
+namespace, while maintaining the private modifier (`$`). With the
+namespace set to e.g. `mysite`, a private channel named `$user.3` will
+be sent to centrifugo as `$mysite:user.3`. This allows for
+site-specific configuration in your centrifugo `config.json`, paving
+way for having several sites on the same centrifugo server, with
+different channel config.
 
 Don't forget to change `BROADCAST_DRIVER` setting in .env file!
 

--- a/src/Centrifugo.php
+++ b/src/Centrifugo.php
@@ -293,6 +293,7 @@ class Centrifugo implements CentrifugoInterface
         $signing_input = implode('.', $segments);
         $signature = $this->sign($signing_input, $this->getSecret());
         $segments[] = $this->urlsafeB64Encode($signature);
+
         return implode('.', $segments);
     }
 

--- a/src/Centrifugo.php
+++ b/src/Centrifugo.php
@@ -389,13 +389,11 @@ class Centrifugo implements CentrifugoInterface
         }
         if (!empty($params['channels'])) {
             array_walk($params['channels'], function (&$channel) {
-                $chan = new Channel($this, $channel);
-                $channel = $chan->getCentrifugoName();
+                $channel = (new Channel($this, $channel))->getCentrifugoName();
             });
         }
         if (!empty($params['channel'])) {
-            $chan = new Channel($this, $params['channel']);
-            $params['channel'] = $chan->getCentrifugoName();
+            $params['channel'] = (new Channel($this, $channel))->getCentrifugoName();
         }
         return $params;
     }

--- a/src/Centrifugo.php
+++ b/src/Centrifugo.php
@@ -395,6 +395,7 @@ class Centrifugo implements CentrifugoInterface
         if (!empty($params['channel'])) {
             $params['channel'] = (new Channel($this, $channel))->getCentrifugoName();
         }
+
         return $params;
     }
 

--- a/src/Centrifugo.php
+++ b/src/Centrifugo.php
@@ -279,11 +279,8 @@ class Centrifugo implements CentrifugoInterface
      */
     public function generatePrivateChannelToken(string $client, string $channel, int $exp = 0, array $info = []): string
     {
-        dump("generating private channel token for $channel");
-        // @var Channel $chan
-        $chan = new Channel($this, $channel);
         $header = ['typ' => 'JWT', 'alg' => 'HS256'];
-        $payload = ['channel' => $chan->getCentrifugoName(), 'client' => $client];
+        $payload = ['channel' => $channel, 'client' => $client];
         if (!empty($info)) {
             $payload['info'] = $info;
         }
@@ -296,7 +293,6 @@ class Centrifugo implements CentrifugoInterface
         $signing_input = implode('.', $segments);
         $signature = $this->sign($signing_input, $this->getSecret());
         $segments[] = $this->urlsafeB64Encode($signature);
-
         return implode('.', $segments);
     }
 
@@ -393,7 +389,7 @@ class Centrifugo implements CentrifugoInterface
         if (!empty($params['channels'])) {
             array_walk($params['channels'], function (&$channel) {
                 $chan = new Channel($this, $channel);
-                $channel = $chan->getCentrifugoChannelName();
+                $channel = $chan->getCentrifugoName();
             });
         }
         if (!empty($params['channel'])) {

--- a/src/Centrifugo.php
+++ b/src/Centrifugo.php
@@ -279,10 +279,11 @@ class Centrifugo implements CentrifugoInterface
      */
     public function generatePrivateChannelToken(string $client, string $channel, int $exp = 0, array $info = []): string
     {
+        dump("generating private channel token for $channel");
         // @var Channel $chan
         $chan = new Channel($this, $channel);
         $header = ['typ' => 'JWT', 'alg' => 'HS256'];
-        $payload = ['channel' => $chan->getCentrifugoChannelName(), 'client' => $client];
+        $payload = ['channel' => $chan->getCentrifugoName(), 'client' => $client];
         if (!empty($info)) {
             $payload['info'] = $info;
         }
@@ -397,7 +398,7 @@ class Centrifugo implements CentrifugoInterface
         }
         if (!empty($params['channel'])) {
             $chan = new Channel($this, $params['channel']);
-            $params['channel'] = $chan->getCentrifugoChannelName();
+            $params['channel'] = $chan->getCentrifugoName();
         }
         return $params;
     }

--- a/src/CentrifugoBroadcaster.php
+++ b/src/CentrifugoBroadcaster.php
@@ -47,7 +47,6 @@ class CentrifugoBroadcaster extends Broadcaster
         $privateResponse = [];
 
         foreach ($channels as $channel) {
-            // @var Channel $chan
             $chan = new Channel($this->centrifugo, $channel);
             try {
                 $is_access_granted = $this->verifyUserCanAccessChannel($request, $chan->getName());
@@ -164,9 +163,11 @@ class CentrifugoBroadcaster extends Broadcaster
         $info = [];
 
         return $access_granted ? [
+
             'channel' => $channel,
             'token'   => $this->centrifugo->generatePrivateChannelToken($client, $channel, 0, $info),
             'info'    => $this->centrifugo->info(),
+
         ] : [
             'status' => 403,
         ];

--- a/src/CentrifugoBroadcaster.php
+++ b/src/CentrifugoBroadcaster.php
@@ -62,6 +62,7 @@ class CentrifugoBroadcaster extends Broadcaster
                     $response[$channel] = $this->makeResponseForClient($is_access_granted, $client);
                 }
             }
+
             return response($privateResponse ?: $response);
         } else {
             throw new HttpException(401);

--- a/src/Channel.php
+++ b/src/Channel.php
@@ -47,8 +47,8 @@ class Channel
     /**
      * Create a channel name manipulator instance.
      *
-     * @param Contracts\CentrifugoInterface $centrifugo
-     * @param string $channel Channel name with or without site namespace.
+     * @param Contracts\CentrifugoInterface $centrifugo Centrifugo instance.
+     * @param string                        $channel    Channel name with or without site namespace.
      */
     public function __construct(Centrifugo $centrifugo, $channel)
     {

--- a/src/Channel.php
+++ b/src/Channel.php
@@ -98,6 +98,7 @@ class Channel
     {
         $privateStr = $this->isPrivate() ? '$' : '';
         $namespaceStr = $this->namespace ? "$this->namespace:" : '';
+
         return $privateStr.$namespaceStr.$this->getName();
     }
 }

--- a/src/Channel.php
+++ b/src/Channel.php
@@ -44,6 +44,12 @@ class Channel
      */
     protected $namespace;
 
+    /**
+     * Create a channel name manipulator instance.
+     *
+     * @param Contracts\CentrifugoInterface $centrifugo
+     * @param string $channel Channel name with or without site namespace.
+     */
     public function __construct(Centrifugo $centrifugo, $channel)
     {
         $this->orig = $channel;

--- a/src/Channel.php
+++ b/src/Channel.php
@@ -86,7 +86,7 @@ class Channel
      */
     public function getInternalName()
     {
-        return ($this->isPrivate() ? '$' : '') . $this->name;
+        return ($this->isPrivate() ? '$' : '').$this->name;
     }
 
     /**
@@ -98,6 +98,6 @@ class Channel
     {
         $privateStr = $this->isPrivate() ? '$' : '';
         $namespaceStr = $this->namespace ? "$this->namespace:" : '';
-        return $privateStr . $namespaceStr . $this->getName();
+        return $privateStr.$namespaceStr.$this->getName();
     }
 }

--- a/src/Channel.php
+++ b/src/Channel.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace denis660\Centrifugo;
 
+/**
+ * Parse and process channel names to and from Centrifugo server.
+ */
 class Channel
 {
     /**
@@ -12,14 +15,14 @@ class Channel
     protected $centrifugo;
 
     /**
-     * The original channel name when instanciated.
+     * The original channel name when instantiated.
      *
      * @var string
      */
     protected $orig;
 
     /**
-     * The 'bare' channel name, with no modifiers.
+     * The 'bare' channel name, with no modifiers and no namespace.
      *
      * @var string
      */
@@ -48,6 +51,12 @@ class Channel
         $this->name = $this->private ? substr($channel, 1) : $channel;
         $this->centrifugo = $centrifugo;
         $this->namespace = $centrifugo->getNamespace();
+        if ($this->namespace) {
+            $parts = explode(':', $this->name);
+            if (count($parts) > 1 && $parts[0] === $this->namespace) {
+                $this->name = substr($this->name, strlen($this->namespace) + 1);
+            }
+        }
     }
 
     /**
@@ -71,11 +80,21 @@ class Channel
     }
 
     /**
+     * Get the channel name as used internally.
+     *
+     * @return string
+     */
+    public function getInternalName()
+    {
+        return ($this->isPrivate() ? '$' : '') . $this->name;
+    }
+
+    /**
      * Return complete channel name sent to centrifugo server.
      *
      * @return string
      */
-    public function getCentrifugoChannelName()
+    public function getCentrifugoName()
     {
         $privateStr = $this->isPrivate() ? '$' : '';
         $namespaceStr = $this->namespace ? "$this->namespace:" : '';

--- a/src/Channel.php
+++ b/src/Channel.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace denis660\Centrifugo;
+
+class Channel
+{
+    /**
+     * @var Contracts\CentrifugoInterface
+     */
+    protected $centrifugo;
+
+    /**
+     * The original channel name when instanciated.
+     *
+     * @var string
+     */
+    protected $orig;
+
+    /**
+     * The 'bare' channel name, with no modifiers.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * Channel private state.
+     *
+     * @var bool
+     */
+    protected $private;
+
+    /**
+     * The centrifugo namespace.
+     *
+     * @see https://centrifugal.dev/docs/server/channels#channel-namespaces
+     *
+     * @var string
+     */
+    protected $namespace;
+
+    public function __construct(Centrifugo $centrifugo, $channel)
+    {
+        $this->orig = $channel;
+        $this->private = substr($channel, 0, 1) === '$';
+        $this->name = $this->private ? substr($channel, 1) : $channel;
+        $this->centrifugo = $centrifugo;
+        $this->namespace = $centrifugo->getNamespace();
+    }
+
+    /**
+     * Get channel private status.
+     *
+     * @return bool
+     */
+    public function isPrivate()
+    {
+        return $this->private;
+    }
+
+    /**
+     * Get the plain channel name, with no modifiers.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Return complete channel name sent to centrifugo server.
+     *
+     * @return string
+     */
+    public function getCentrifugoChannelName()
+    {
+        $privateStr = $this->isPrivate() ? '$' : '';
+        $namespaceStr = $this->namespace ? "$this->namespace:" : '';
+        return $privateStr . $namespaceStr . $this->getName();
+    }
+}


### PR DESCRIPTION
When having several sites run on the same centrifugo server, the channel names and channel config may be in conflict. Centrifugo has support for channel namespaces, which is a perfect place to group site-wide channels in.

This PR is an attempt at keeping the internal Laravel channel names 'clean' (without namespaces), and when sending them to centrifugo, prefix them with the configured namespace for this site. It's still possible to drop site-wide namespaces and add namespaces to channels manually, but the two may not mix.

This will also remove the pain with adding custom namespace on channel names for model broadcasting, and other laravel 'magic' channel name generation.

Please review, consider, and test. It's *not* well tested. I have this working on two sites with two different namespaces and their custom centrifugo config, one using only public channels, the other only private.

P.S. The commits and commit log is gibberish, so please do a squash merge, if applicable.