### PR TITLE
Fixed a bug with a user ID in generatePrivateChannelToken

### DIFF
--- a/src/Centrifugo.php
+++ b/src/Centrifugo.php
@@ -269,17 +269,17 @@ class Centrifugo implements CentrifugoInterface
     /**
      * Generate private channel token.
      *
-     * @param string $client
+     * @param string $userId
      * @param string $channel
      * @param int    $exp
      * @param array  $info
      *
      * @return string
      */
-    public function generatePrivateChannelToken(string $client, string $channel, int $exp = 0, array $info = []): string
+    public function generatePrivateChannelToken(string $userId, string $channel, int $exp = 0, array $info = []): string
     {
         $header = ['typ' => 'JWT', 'alg' => 'HS256'];
-        $payload = ['channel' => $channel, 'client' => $client];
+        $payload = ['channel' => $channel, 'sub' => $userId];
         if (!empty($info)) {
             $payload['info'] = $info;
         }


### PR DESCRIPTION
Point me if I'm wrong but according to https://centrifugal.dev/docs/server/channel_token_auth#sub there should be a `sub` param instead of `client` to generate a proper private channel key for selected user ID. Without it getting `invalid token` response and also `centrifugo checksubtoken -c config.json <TOKEN>` shows "valid subscription token for anonymous user and channel "channel"".