### PR TITLE
fix(info): pass valid request

### DIFF
--- a/src/Centrifugo.php
+++ b/src/Centrifugo.php
@@ -231,7 +231,7 @@ class Centrifugo implements CentrifugoInterface
      */
     public function info() : array
     {
-        return $this->send('info');
+        return $this->send('info', new \stdClass());
     }
 
     /**
@@ -328,7 +328,7 @@ class Centrifugo implements CentrifugoInterface
      * @return mixed
      * @throws GuzzleException
      */
-    protected function send(string $method, array $params = []) : array
+    protected function send(string $method, array|\stdClass $params = []) : array
     {
         $url = $this->prepareUrl();
 


### PR DESCRIPTION
Centrifugo v6.2.3 (Go version: go1.24.5)

Details: If we pass an array in the request body for api/info, we get a 400 Bad Request error.

Centrifugo Log: `[ERR] error decoding API request body error="json: cannot unmarshal array into Go value of type apiproto.InfoRequest" path=/api/info`